### PR TITLE
Support for spring 2.5 and java 6

### DIFF
--- a/springockito/BeanAutowiringMock.java
+++ b/springockito/BeanAutowiringMock.java
@@ -1,0 +1,23 @@
+package org.kubek2k.mockito.spring.testbeans;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BeanAutowiringMock {
+
+    private final InterfaceToBeMocked interfaceToBeMocked;
+
+    @Autowired
+    public BeanAutowiringMock(InterfaceToBeMocked interfaceToBeMocked) {
+        this.interfaceToBeMocked = interfaceToBeMocked;
+    }
+
+    public InterfaceToBeMocked getInterfaceToBeMocked() {
+        return interfaceToBeMocked;
+    }
+    
+    public Integer getValue() {
+        return interfaceToBeMocked.getValue();
+    }
+}

--- a/springockito/BeanToBeInjectedWithSpy.java
+++ b/springockito/BeanToBeInjectedWithSpy.java
@@ -1,0 +1,21 @@
+package org.kubek2k.mockito.spring.testbeans;
+
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+@Component
+public class BeanToBeInjectedWithSpy {
+
+    private BeanToBeSpiedOrMockedAndStubbed beanToBeSpiedOrMockedAndStubbed;
+
+    public void callMethodWithoutArgumentsOnInjectedBeanTwice() {
+        beanToBeSpiedOrMockedAndStubbed.methodWithoutArgument();
+        beanToBeSpiedOrMockedAndStubbed.methodWithoutArgument();
+    }
+
+    @Resource
+    public void setBeanToBeSpiedOrMockedAndStubbed(BeanToBeSpiedOrMockedAndStubbed beanToBeSpiedOrMockedAndStubbed) {
+        this.beanToBeSpiedOrMockedAndStubbed = beanToBeSpiedOrMockedAndStubbed;
+    }
+}

--- a/springockito/BeanToBeSpiedOrMockedAndStubbed.java
+++ b/springockito/BeanToBeSpiedOrMockedAndStubbed.java
@@ -1,0 +1,15 @@
+package org.kubek2k.mockito.spring.testbeans;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BeanToBeSpiedOrMockedAndStubbed {
+
+    public String methodWithArgument(String string) {
+        return string;
+    }
+
+    public void methodWithoutArgument() {
+    }
+
+}

--- a/springockito/InterfaceToBeMocked.java
+++ b/springockito/InterfaceToBeMocked.java
@@ -1,0 +1,5 @@
+package org.kubek2k.mockito.spring.testbeans;
+
+public interface InterfaceToBeMocked {
+    public Integer getValue(); 
+}

--- a/springockito/MockFactoryBean.java
+++ b/springockito/MockFactoryBean.java
@@ -1,0 +1,52 @@
+package org.kubek2k.mockito.spring.factory;
+
+import org.mockito.Mockito;
+import org.springframework.beans.factory.FactoryBean;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class MockFactoryBean<T> implements FactoryBean {
+
+    private Class<T> mockClass;
+    private String beanId;
+    private boolean useStaticMap;
+
+    private T thisInstance;
+
+    private static Map<String, Object> objectMap = new HashMap<String, Object>();
+
+    public MockFactoryBean(Class<T> mockClass, String beanId, boolean useStaticMap) {
+        this.mockClass = mockClass;
+        this.beanId = beanId;
+        this.useStaticMap = useStaticMap;
+    }
+
+    public Class<? extends T> getObjectType() {
+        return mockClass;
+    }
+
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public T getObject() throws Exception {
+        if (useStaticMap) {
+            T instance = (T) objectMap.get(beanId);
+
+            if (instance == null) {
+                instance = Mockito.mock(mockClass);
+                objectMap.put(beanId, instance);
+            }
+
+            return instance;
+            
+        } else {
+            if (thisInstance == null) {
+                thisInstance = Mockito.mock(mockClass);
+            }
+            return thisInstance;
+        }
+    }
+
+}

--- a/springockito/MockitoMockAutowiringIntegrationTest.java
+++ b/springockito/MockitoMockAutowiringIntegrationTest.java
@@ -1,0 +1,5 @@
+package org.kubek2k.mockito.spring;
+
+public class MockitoMockAutowiringIntegrationTest {
+
+}

--- a/springockito/MockitoMockBeanDefinitionParser.java
+++ b/springockito/MockitoMockBeanDefinitionParser.java
@@ -1,0 +1,27 @@
+package org.kubek2k.mockito.spring;
+
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.w3c.dom.Element;
+
+public class MockitoMockBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+    
+    @Override
+    protected String getBeanClassName(Element element) {
+        return "org.kubek2k.mockito.spring.factory.MockFactoryBean";
+    }
+    
+    @Override
+    protected void doParse(Element element, BeanDefinitionBuilder bean) {
+        bean.addConstructorArgValue(element.getAttribute("class"));
+        bean.addConstructorArgValue(element.getAttribute("id"));
+        bean.addConstructorArgValue(element.getAttribute("useStaticMap"));
+    }
+
+    @Override
+    protected void postProcessComponentDefinition(BeanComponentDefinition componentDefinition) {
+        super.postProcessComponentDefinition(componentDefinition);
+        componentDefinition.getBeanDefinition().setAutowireCandidate(true);
+    }
+}

--- a/springockito/MockitoMockHandlerComponentScanIntegrationTest.java
+++ b/springockito/MockitoMockHandlerComponentScanIntegrationTest.java
@@ -1,0 +1,22 @@
+package org.kubek2k.mockito.spring;
+
+import static org.testng.Assert.assertNotNull;
+
+import org.kubek2k.mockito.spring.testbeans.BeanAutowiringMock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+@ContextConfiguration(locations={"classpath:spring/mockitoComponentScanContext.xml"})
+public class MockitoMockHandlerComponentScanIntegrationTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired
+    private BeanAutowiringMock beanAutowiringMock;
+
+    @Test
+    public void shouldAutowireMocksInSpringBeansWhenUsingComponentScan() {
+        assertNotNull(beanAutowiringMock);
+        assertNotNull(beanAutowiringMock.getInterfaceToBeMocked());
+    }
+}

--- a/springockito/MockitoMockHandlerIntegrationTest.java
+++ b/springockito/MockitoMockHandlerIntegrationTest.java
@@ -1,0 +1,57 @@
+package org.kubek2k.mockito.spring;
+
+import org.kubek2k.mockito.spring.testbeans.BeanToBeSpiedOrMockedAndStubbed;
+import org.mockito.cglib.proxy.Factory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+import javax.annotation.Resource;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+@ContextConfiguration(locations = {"classpath*:/spring/mockitoContext.xml"})
+public class MockitoMockHandlerIntegrationTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired
+    private SomeFancyClass someFancyClass;
+
+    @Autowired
+    @Qualifier("someFancyClass")
+    private SomeFancyClass someFancyClass2;
+
+    @Resource
+    private BeanToBeSpiedOrMockedAndStubbed beanToBeMockedAndStubbed;
+
+    @Test
+    public void shouldLoadMockitoMock() {
+        assertNotNull(someFancyClass);
+        assertTrue(someFancyClass instanceof Factory);
+
+        assertNotNull(someFancyClass2);
+        assertTrue(someFancyClass2 instanceof Factory);
+
+    }
+
+    @Test
+    public void shouldAllowForMocksTeBeStubbedUsingMockitoMatchers() {
+        //given
+        String fixedReturnValue = "fixedReturnValue";
+        given(beanToBeMockedAndStubbed.methodWithArgument(anyString()))
+                .willReturn(fixedReturnValue);
+
+        //when
+        String returnedString = beanToBeMockedAndStubbed.methodWithArgument("someString");
+
+        //then
+        assertThat(returnedString)
+                .isEqualTo(fixedReturnValue);
+    }
+}

--- a/springockito/MockitoNamespaceHandler.java
+++ b/springockito/MockitoNamespaceHandler.java
@@ -1,0 +1,13 @@
+package org.kubek2k.mockito.spring;
+
+import org.springframework.beans.factory.xml.NamespaceHandler;
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+public class MockitoNamespaceHandler extends NamespaceHandlerSupport implements NamespaceHandler {
+
+    public void init() {
+        registerBeanDefinitionParser("mock", new MockitoMockBeanDefinitionParser());
+        registerBeanDefinitionParser("spy", new MockitoSpyBeanDefinitionParser());
+    }
+
+}

--- a/springockito/MockitoSpyBeanDefinitionParser.java
+++ b/springockito/MockitoSpyBeanDefinitionParser.java
@@ -1,0 +1,23 @@
+package org.kubek2k.mockito.spring;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.w3c.dom.Element;
+
+public class MockitoSpyBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+    @Override
+    protected String getBeanClassName(Element element) {
+        return "org.kubek2k.mockito.spring.MockitoSpyBeanPostProcessor";
+    }
+
+    @Override
+    protected void doParse(Element element, BeanDefinitionBuilder beanBuilder) {
+        beanBuilder.addPropertyValue("beanName", element.getAttribute("beanName"));
+    }
+    
+    @Override
+    protected boolean shouldGenerateIdAsFallback() {
+        return true;
+    }
+}

--- a/springockito/MockitoSpyBeanPostProcessor.java
+++ b/springockito/MockitoSpyBeanPostProcessor.java
@@ -1,0 +1,26 @@
+  package org.kubek2k.mockito.spring;
+
+import org.mockito.Mockito;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+public class MockitoSpyBeanPostProcessor implements BeanPostProcessor {
+
+    private String beanName;
+
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (this.beanName.equals(beanName)) {
+            return Mockito.spy(bean);
+        } else {
+            return bean;
+        }
+    }
+    public void setBeanName(String matchingName) {
+        this.beanName = matchingName;
+    }
+
+}

--- a/springockito/MockitoSpyHandlerIntegrationTest.java
+++ b/springockito/MockitoSpyHandlerIntegrationTest.java
@@ -1,0 +1,67 @@
+package org.kubek2k.mockito.spring;
+
+import org.kubek2k.mockito.spring.testbeans.BeanToBeInjectedWithSpy;
+import org.kubek2k.mockito.spring.testbeans.BeanToBeSpiedOrMockedAndStubbed;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+import javax.annotation.Resource;
+import java.util.Date;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ContextConfiguration(locations = {"classpath*:/spring/parentContext.xml", "classpath*:/spring/mockitoSpyContext.xml"})
+public class MockitoSpyHandlerIntegrationTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired
+    private Date dateToBeSpied;
+
+    @Resource
+    private BeanToBeSpiedOrMockedAndStubbed beanToBeSpiedAndStubbed;
+
+
+    @Resource
+    BeanToBeInjectedWithSpy beanToBeInjectedWithSpy;
+
+
+    @Test
+    public void shouldLoadMockitoSpy() {
+        dateToBeSpied.compareTo(new Date());
+        verify(dateToBeSpied).compareTo(isA(Date.class));
+    }
+
+    @Test
+    public void shouldAllowForSpiesTeBeStubbedUsingMockitoMatchers() {
+        //given
+        String fixedReturnValue = "fixedReturnValue";
+        given(beanToBeSpiedAndStubbed.methodWithArgument(anyString()))
+                .willReturn(fixedReturnValue);
+
+        //when
+        String returnedString = beanToBeSpiedAndStubbed.methodWithArgument("someString");
+
+        //then
+        assertThat(returnedString)
+                .isEqualTo(fixedReturnValue);
+    }
+
+    @Test
+    public void shouldInjectSpyOfTheBeanInsteadOfOriginalOneEverywhere() {
+        //given
+        int expectedAmountOfSpyMethodInvocations = 2;
+
+        //when
+        beanToBeInjectedWithSpy.callMethodWithoutArgumentsOnInjectedBeanTwice();
+
+        //then
+        verify(beanToBeSpiedAndStubbed, times(expectedAmountOfSpyMethodInvocations))
+                .methodWithoutArgument();
+    }
+}

--- a/springockito/MultiThreadingIntegrationTest.java
+++ b/springockito/MultiThreadingIntegrationTest.java
@@ -1,0 +1,125 @@
+package org.kubek2k.mockito.spring;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.kubek2k.mockito.spring.testbeans.BeanAutowiringMock;
+import org.kubek2k.mockito.spring.testbeans.InterfaceToBeMocked;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+@ContextConfiguration(locations = { "classpath:spring/mockitoComponentScanContext.xml" })
+public class MultiThreadingIntegrationTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired
+    private BeanAutowiringMock beanAutowiringMock;
+
+    @Autowired
+    private InterfaceToBeMocked interfaceToBeMocked;
+
+    /**
+     * We want to have a situation when two separately run tests have separate
+     * mocks injected. I have to use a new thread to spawn tests - it's
+     * something like a junittestrunner simulator - it's caused by the fact that
+     * we'll use {@link InheritableThreadLocal} to keep an instance of current
+     * mocks - please
+     * {@link MultiThreadingIntegrationTest#shouldInheritMocksWhenCodeThatIsBeingSpawnedByTestSpawnsANewThreads()}
+     */
+    @Test
+    public void shouldAllowConcurrentAccessToMockitoMocks() throws InterruptedException {
+        final AtomicBoolean test1AssertionOutcome = new AtomicBoolean(false);
+        final AtomicBoolean test2AssertionOutcome = new AtomicBoolean(false);
+
+        Thread testRunner = new Thread() {
+            @Override
+            public void run() {
+                Thread test1Runner = new Thread() {
+                    @Override
+                    public void run() {
+                        when(interfaceToBeMocked.getValue()).thenReturn(1);
+                        assertAndSetOutcomeVariable(beanAutowiringMock.getValue(), 1, test1AssertionOutcome);
+                    }
+
+                };
+
+                Thread test2Runner = new Thread() {
+                    @Override
+                    public void run() {
+                        when(interfaceToBeMocked.getValue()).thenReturn(2);
+                        assertAndSetOutcomeVariable(beanAutowiringMock.getValue(), 2, test2AssertionOutcome);
+                    }
+                };
+
+                test1Runner.start();
+                test2Runner.start();
+
+                try {
+                    test1Runner.join();
+                    test2Runner.join();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    test1AssertionOutcome.set(false);
+                    test2AssertionOutcome.set(false);
+                }
+            }
+        };
+        testRunner.start();
+        testRunner.join();
+
+        assertTrue(test1AssertionOutcome.get());
+        assertTrue(test2AssertionOutcome.get());
+    }
+    
+
+
+    /**
+     * Check that all threads spawned by application code gets an access to the 
+     * same mock
+     */
+    @Test
+    public void shouldInheritMocksWhenCodeThatIsBeingSpawnedByTestSpawnsANewThreads() throws InterruptedException {
+
+        final AtomicBoolean inheritedValueAssertionOutcome = new AtomicBoolean(false);
+        Thread testRunner = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    when(interfaceToBeMocked.getValue()).thenReturn(11);
+
+                    // we simulate that tested code actually spawned a new
+                    // thread
+                    Thread inheritingThread = new Thread() {
+                        @Override
+                        public void run() {
+                            // the simulating code is executing mocks' recorded
+                            // codetry {
+                            assertAndSetOutcomeVariable(beanAutowiringMock.getValue(), 11, inheritedValueAssertionOutcome);
+                        }
+                    };
+
+                    inheritingThread.start();
+                    inheritingThread.join();
+                    
+                } catch (InterruptedException e) {
+                    inheritedValueAssertionOutcome.set(false);
+                }
+            }
+
+        };
+
+        testRunner.start();
+        testRunner.join();
+
+        assertTrue(inheritedValueAssertionOutcome.get());
+    }
+
+    private void assertAndSetOutcomeVariable(Integer value, Integer expectedValue, final AtomicBoolean outcomeVariable) {
+        assertEquals(value, Integer.valueOf(expectedValue));
+        outcomeVariable.set(value.equals(expectedValue));
+    }
+}

--- a/springockito/SomeFancyClass.java
+++ b/springockito/SomeFancyClass.java
@@ -1,0 +1,5 @@
+package org.kubek2k.mockito.spring;
+
+public class SomeFancyClass {
+
+}

--- a/springockito/ThreadLocalMockMethodInterceptor.java
+++ b/springockito/ThreadLocalMockMethodInterceptor.java
@@ -1,0 +1,36 @@
+package org.kubek2k.mockito.spring.factory;
+
+import java.lang.reflect.Method;
+
+import org.mockito.Mockito;
+import org.mockito.cglib.proxy.MethodInterceptor;
+import org.mockito.cglib.proxy.MethodProxy;
+
+public class ThreadLocalMockMethodInterceptor<T> implements MethodInterceptor {
+    
+    private InheritableThreadLocal<T> mockLocalForCurrentThread;
+    private Class<T> mockClass;
+    
+    public ThreadLocalMockMethodInterceptor(Class<T> mockClass) {
+        this.mockClass = mockClass;
+        mockLocalForCurrentThread = new InheritableThreadLocal<T>();
+    }
+
+    private T getOrCreateMockForCurrentThread() {
+        T threadLocalInstance = mockLocalForCurrentThread.get();
+        if (threadLocalInstance == null) {
+            threadLocalInstance = createMock();
+            mockLocalForCurrentThread.set(threadLocalInstance);
+        }
+        return threadLocalInstance;
+    }
+
+    public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
+        return method.invoke(getOrCreateMockForCurrentThread(), args);
+    }
+
+
+    private T createMock() {
+        return Mockito.mock(mockClass);
+    }
+}

--- a/springockito/pom.xml
+++ b/springockito/pom.xml
@@ -1,60 +1,111 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.kubek2k</groupId>
-    <artifactId>springockito</artifactId>
-    <version>1.0.10-SNAPSHOT</version>
-    <url>https://bitbucket.org/kubek2k/springockito</url>
-    <description>Simple tool to create mocks in Spring environment</description>
-    <name>Springockito</name>
+    <artifactId>springockito-spring25</artifactId>
+    <version>1.0.10</version>
+    <url>https://bitbucket.org/przeeemek/springockito-spring25</url>
+    <description>Simple tool to create mocks in Spring environment - </description>
+    <name>Springockito with Spring 2.5 support</name>
 
-    <parent>
-        <groupId>org.kubek2k</groupId>
-        <artifactId>springockito-parent</artifactId>
-        <version>1.0.7</version>
-    </parent>
-
-    <scm>
-        <url>https://bitbucket.org/kubek2k/springockito</url>
-        <connection>https://bitbucket.org/kubek2k/springockito</connection>
-        <developerConnection>scm:hg:https://bitbucket.org/kubek2k/springockito</developerConnection>
-    </scm>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.version>2.5.6</spring.version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
+            <artifactId>spring</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-expression</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-
         <!--test-->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <version>1.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <version>6.3.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.1.2</version>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.8</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.2.2</version>
+                    <configuration>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <arguments>-Psonatype-oss-release</arguments>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/springockito/spring.handlers
+++ b/springockito/spring.handlers
@@ -1,0 +1,1 @@
+http\://www.mockito.org/spring/mockito=org.kubek2k.mockito.spring.MockitoNamespaceHandler


### PR DESCRIPTION
Unfortunately some of us have to deal with legacy code and a bit outdated technologies.
here comes support for spring mocks for java 6 & spring 2.5
